### PR TITLE
Fixed wrong path regex

### DIFF
--- a/.bin/swagged-angular-resources
+++ b/.bin/swagged-angular-resources
@@ -2,11 +2,13 @@
 
 fs = require "fs"
 request = require "request"
+path = require "path"
 url = require "url"
 _ = require "underscore"
 _.str = require "underscore.string"
 handlebars = require "handlebars"
 argv = require("yargs").argv
+mkdirp = require "mkdirp"
 
 if argv._.length == 0
   throw "Expected: swagged-angular-resources swagger-docs-url|swagger-docs-file [--ngmodule swaggedAngularResources [--strip-trailing-slashes false [--output index.js [--mock-output false]]]]"
@@ -59,7 +61,7 @@ getResourceOperations = (apiDefinition) ->
         memo[modelDefinition] = memo[modelDefinition] || []
 
         memo[modelDefinition].push({
-          path: path.replace(/\{(.+)\}/g, ":$1")
+          path: path.replace(/\{(.+?)\}/g, ":$1")
           nickname: operation.operationId || modelDefinition + "_" + _.str.capitalize(action)
           action: action.toUpperCase()
           summary: operation.summary
@@ -103,6 +105,8 @@ getCode = (error, apiDefinition) ->
       throw error
     else
       code = handlebars.compile(template)(context)
+      mkdirp.sync path.dirname(ngModuleOutput) if not fs.existsSync ngModuleOutput
+        
       fs.writeFile(ngModuleOutput, code, {encoding: "utf-8"}, (error) ->
         if error
           throw error
@@ -116,6 +120,7 @@ getCode = (error, apiDefinition) ->
       else
         log ngMockModuleOutput
         code = handlebars.compile(template)(context)
+        mkdirp.sync path.dirname(ngMockModuleOutput) if not fs.existsSync ngMockModuleOutput
         fs.writeFile(ngMockModuleOutput, code, {encoding: "utf-8"}, (error) ->
           if error
             throw error

--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
     "gulp-rename": "^1.2.0"
   },
   "dependencies": {
+    "coffee-script": "^1.8.0",
     "handlebars": "^2.0.0",
+    "mkdirp": "^0.5.1",
     "request": "^2.49.0",
     "underscore": "^1.7.0",
     "underscore.string": "^2.4.0",
-    "yargs": "^3.6.0",
-    "coffee-script": "^1.8.0"
+    "yargs": "^3.6.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/src/swagged-angular-resources.coffee
+++ b/src/swagged-angular-resources.coffee
@@ -7,6 +7,7 @@ _ = require "underscore"
 _.str = require "underscore.string"
 handlebars = require "handlebars"
 argv = require("yargs").argv
+mkdirp = require 'mkdirp'
 
 if argv._.length == 0
   throw "Expected: swagged-angular-resources swagger-docs-url|swagger-docs-file [--ngmodule swaggedAngularResources [--strip-trailing-slashes false [--output index.js [--mock-output false]]]]"
@@ -103,6 +104,8 @@ getCode = (error, apiDefinition) ->
       throw error
     else
       code = handlebars.compile(template)(context)
+      mkdirp.sync ngModuleOutput if not fs.existsSync ngModuleOutput
+        
       fs.writeFile(ngModuleOutput, code, {encoding: "utf-8"}, (error) ->
         if error
           throw error
@@ -116,6 +119,7 @@ getCode = (error, apiDefinition) ->
       else
         log ngMockModuleOutput
         code = handlebars.compile(template)(context)
+        mkdirp.sync ngMockModuleOutput if not fs.existsSync ngMockModuleOutput
         fs.writeFile(ngMockModuleOutput, code, {encoding: "utf-8"}, (error) ->
           if error
             throw error

--- a/src/swagged-angular-resources.coffee
+++ b/src/swagged-angular-resources.coffee
@@ -2,12 +2,13 @@
 
 fs = require "fs"
 request = require "request"
+path = require "path"
 url = require "url"
 _ = require "underscore"
 _.str = require "underscore.string"
 handlebars = require "handlebars"
 argv = require("yargs").argv
-mkdirp = require 'mkdirp'
+mkdirp = require "mkdirp"
 
 if argv._.length == 0
   throw "Expected: swagged-angular-resources swagger-docs-url|swagger-docs-file [--ngmodule swaggedAngularResources [--strip-trailing-slashes false [--output index.js [--mock-output false]]]]"
@@ -104,7 +105,7 @@ getCode = (error, apiDefinition) ->
       throw error
     else
       code = handlebars.compile(template)(context)
-      mkdirp.sync ngModuleOutput if not fs.existsSync ngModuleOutput
+      mkdirp.sync path.dirname(ngModuleOutput) if not fs.existsSync ngModuleOutput
         
       fs.writeFile(ngModuleOutput, code, {encoding: "utf-8"}, (error) ->
         if error
@@ -119,7 +120,7 @@ getCode = (error, apiDefinition) ->
       else
         log ngMockModuleOutput
         code = handlebars.compile(template)(context)
-        mkdirp.sync ngMockModuleOutput if not fs.existsSync ngMockModuleOutput
+        mkdirp.sync path.dirname(ngMockModuleOutput) if not fs.existsSync ngMockModuleOutput
         fs.writeFile(ngMockModuleOutput, code, {encoding: "utf-8"}, (error) ->
           if error
             throw error

--- a/src/swagged-angular-resources.coffee
+++ b/src/swagged-angular-resources.coffee
@@ -59,7 +59,7 @@ getResourceOperations = (apiDefinition) ->
         memo[modelDefinition] = memo[modelDefinition] || []
 
         memo[modelDefinition].push({
-          path: path.replace(/\{(.+)\}/g, ":$1")
+          path: path.replace(/\{(.+?)\}/g, ":$1")
           nickname: operation.operationId || modelDefinition + "_" + _.str.capitalize(action)
           action: action.toUpperCase()
           summary: operation.summary

--- a/templates/resource-providers.hbs
+++ b/templates/resource-providers.hbs
@@ -4,9 +4,7 @@
   var moduleName = '{{ngModule}}';
 
   angular
-    .module(moduleName, [
-      require('angular-resource')
-    ])
+    .module(moduleName, ['ngResource'])
     .provider('$resourceActionConfig', function () {
       var actionConfigs = {$global: {}};
 


### PR DESCRIPTION
You regex for the Path URL is greedy so only paths with one variable parameter will work
`/posts/{postId}/comments` => `/posts/:postId/comments`

but paths with two or more parameter will not work, only the most outer curly braces will get replaced
`/posts/{postId}/comments/{commentId}` => `/posts/:postId}/comments/{commentId`
`/posts/{postId}/comments/{commentId}/user/{userId}` => `/posts/:postId}/comments/{commentId}/user/{userId`
etc.

The fix is a simple `?` to make it ungreedy
